### PR TITLE
fix: social channels space

### DIFF
--- a/src/components/Home/Notification/index.scss
+++ b/src/components/Home/Notification/index.scss
@@ -15,6 +15,8 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: space-between;
+    width: 50%;
   }
   .content {
     box-shadow: 0px 4px 7px rgba(0, 0, 0, 0.25);

--- a/src/components/Home/Notification/index.scss
+++ b/src/components/Home/Notification/index.scss
@@ -17,6 +17,9 @@
     align-items: center;
     justify-content: space-between;
     width: 50%;
+    @include breakpoint(mobileonly) {
+      width: 80%;
+    }
   }
   .content {
     box-shadow: 0px 4px 7px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
Give social  icons some space to breathe 😮‍💨 

# Before
![Screenshot from 2021-09-23 15-37-08](https://user-images.githubusercontent.com/60013703/134527864-3301f552-acfe-4a0c-8854-f6c75a664cb8.png)

# After
![Screenshot from 2021-09-23 15-37-24](https://user-images.githubusercontent.com/60013703/134527889-e77ed914-33a2-4054-8282-bb8b0798d7ef.png)


