### PR TITLE
fix: contact us form name input width

### DIFF
--- a/src/components/Search/index.scss
+++ b/src/components/Search/index.scss
@@ -174,7 +174,6 @@
     float: none;
     display: block;
     text-align: left;
-    width: 100%;
     margin: 0;
     padding: 14px;
   }


### PR DESCRIPTION
Hello 👋🏻

In this PR I've fixed Contact us form "Name" input width in mobile screen

# Before
![Screenshot from 2021-10-07 15-43-04](https://user-images.githubusercontent.com/60013703/136408548-83f27b79-09f1-4c8c-b76d-c5655ed2073f.png)

# After
![Screenshot from 2021-10-07 15-43-17](https://user-images.githubusercontent.com/60013703/136408628-891bb347-ea04-4d21-8563-bc3d3861e9f2.png)

